### PR TITLE
Update client library and use retry strategy

### DIFF
--- a/Jellyfin.Plugin.TvMaze/Jellyfin.Plugin.TvMaze.csproj
+++ b/Jellyfin.Plugin.TvMaze/Jellyfin.Plugin.TvMaze.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
         <PackageReference Include="Jellyfin.Data" Version="10.*-*" />
         <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
-        <PackageReference Include="TvMaze.Api.Client" Version="0.0.44" />
+        <PackageReference Include="TvMaze.Api.Client" Version="0.1.71" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     </ItemGroup>
 

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeEpisodeImageProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeEpisodeImageProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -12,6 +12,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using TvMaze.Api.Client;
+using TvMaze.Api.Client.Configuration;
 
 namespace Jellyfin.Plugin.TvMaze.Providers
 {
@@ -76,7 +77,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                     return Enumerable.Empty<RemoteImageInfo>();
                 }
 
-                var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default));
+                var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
                 var tvMazeEpisode = await tvMazeClient.Shows.GetEpisodeByNumberAsync(tvMazeId.Value, episode.ParentIndexNumber.Value, episode.IndexNumber.Value).ConfigureAwait(false);
                 if (tvMazeEpisode == null)
                 {

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeEpisodeProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeEpisodeProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -12,6 +12,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using TvMaze.Api.Client;
+using TvMaze.Api.Client.Configuration;
 
 namespace Jellyfin.Plugin.TvMaze.Providers
 {
@@ -122,7 +123,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                 return null;
             }
 
-            var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default));
+            var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
             var tvMazeEpisode = await tvMazeClient.Shows.GetEpisodeByNumberAsync(tvMazeId.Value, info.ParentIndexNumber.Value, info.IndexNumber.Value).ConfigureAwait(false);
             if (tvMazeEpisode == null)
             {

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonImageProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonImageProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -12,6 +12,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using TvMaze.Api.Client;
+using TvMaze.Api.Client.Configuration;
 
 namespace Jellyfin.Plugin.TvMaze.Providers
 {
@@ -94,7 +95,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                 return Enumerable.Empty<RemoteImageInfo>();
             }
 
-            var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default));
+            var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
             var tvMazeSeasons = await tvMazeClient.Shows.GetShowSeasonsAsync(tvMazeId.Value).ConfigureAwait(false);
             if (tvMazeSeasons == null)
             {

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
@@ -11,6 +11,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using TvMaze.Api.Client;
+using TvMaze.Api.Client.Configuration;
 
 namespace Jellyfin.Plugin.TvMaze.Providers
 {
@@ -109,7 +110,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                 return null;
             }
 
-            var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default));
+            var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
             var tvMazeSeasons = await tvMazeClient.Shows.GetShowSeasonsAsync(tvMazeId.Value).ConfigureAwait(false);
             if (tvMazeSeasons == null)
             {

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeriesImageProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeriesImageProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -12,6 +12,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using TvMaze.Api.Client;
+using TvMaze.Api.Client.Configuration;
 using TvMaze.Api.Client.Models;
 
 namespace Jellyfin.Plugin.TvMaze.Providers
@@ -67,7 +68,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                     return Enumerable.Empty<RemoteImageInfo>();
                 }
 
-                var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default));
+                var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
                 var images = await tvMazeClient.Shows.GetShowImagesAsync(tvMazeId.Value).ConfigureAwait(false);
                 if (images == null)
                 {

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeriesProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeriesProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -14,6 +14,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using TvMaze.Api.Client;
+using TvMaze.Api.Client.Configuration;
 using TvMaze.Api.Client.Models;
 
 namespace Jellyfin.Plugin.TvMaze.Providers
@@ -52,7 +53,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
             try
             {
                 _logger.LogDebug("[GetSearchResults] Starting for {name}", searchInfo.Name);
-                var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default));
+                var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
                 var showSearchResults = (await tvMazeClient.Search.ShowSearchAsync(searchInfo.Name?.Trim()).ConfigureAwait(false)).ToList();
                 _logger.LogDebug("[GetSearchResults] Result count for {name}: {count}", searchInfo.Name, showSearchResults.Count);
                 var searchResults = new List<RemoteSearchResult>();
@@ -92,7 +93,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
             try
             {
                 _logger.LogDebug("[GetMetadata] Starting for {name}", info.Name);
-                var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default));
+                var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
                 var result = new MetadataResult<Series>();
 
                 var tvMazeId = TvHelpers.GetTvMazeId(info.ProviderIds);
@@ -108,7 +109,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                     && !string.IsNullOrEmpty(imdbId))
                 {
                     // Lookup by imdb id.
-                    tvMazeShow = await tvMazeClient.Lookup.GetShowByImdbId(imdbId).ConfigureAwait(false);
+                    tvMazeShow = await tvMazeClient.Lookup.GetShowByImdbIdAsync(imdbId).ConfigureAwait(false);
                 }
 
                 if (tvMazeShow == null
@@ -117,7 +118,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                 {
                     // Lookup by tv rage id.
                     var id = Convert.ToInt32(tvRageId, CultureInfo.InvariantCulture);
-                    tvMazeShow = await tvMazeClient.Lookup.GetShowByTvRageId(id).ConfigureAwait(false);
+                    tvMazeShow = await tvMazeClient.Lookup.GetShowByTvRageIdAsync(id).ConfigureAwait(false);
                 }
 
                 if (tvMazeShow == null
@@ -125,7 +126,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                     && !string.IsNullOrEmpty(tvdbId))
                 {
                     var id = Convert.ToInt32(tvdbId, CultureInfo.InvariantCulture);
-                    tvMazeShow = await tvMazeClient.Lookup.GetShowByTheTvdbId(id).ConfigureAwait(false);
+                    tvMazeShow = await tvMazeClient.Lookup.GetShowByTheTvdbIdAsync(id).ConfigureAwait(false);
                 }
 
                 if (tvMazeShow == null)

--- a/build.yaml
+++ b/build.yaml
@@ -12,5 +12,8 @@ category: "Metadata"
 artifacts:
 - "Jellyfin.Plugin.TvMaze.dll"
 - "TvMaze.Api.Client.dll"
+- "Flurl.dll"
+- "Flurl.Http.dll"
+- "Polly.dll"
 changelog: >
   Fix lookup by tvdb id


### PR DESCRIPTION
Updates the client library (like #18) but also updates the changed function names and takes advantage of the new retry strategy, if the rate limit of the API is reached (which can happen quite fast in a library scan)