### PR TITLE
Use the TvMaze Season ID and Episode ID if known.

### DIFF
--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeEpisodeProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeEpisodeProvider.cs
@@ -135,14 +135,30 @@ namespace Jellyfin.Plugin.TvMaze.Providers
 
         private async Task<Episode?> GetMetadataInternal(EpisodeInfo info)
         {
+            var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
+
+            var directEpisodeId = TvHelpers.GetTvMazeId(info.ProviderIds);
+            if (directEpisodeId.HasValue)
+            {
+                var directEpisode = await _memoryCache.GetOrCreateAsync($"{MemoryCachePrefix}_episode_{directEpisodeId.Value}", async entry =>
+                {
+                    entry
+                        .SetAbsoluteExpiration(_absoluteCacheExpiration)
+                        .SetSlidingExpiration(_slidingCacheExpiration);
+                    return await tvMazeClient.Episodes.GetEpisodeMainInformationAsync(directEpisodeId.Value).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+                if (directEpisode != null)
+                {
+                    return MapEpisode(directEpisode);
+                }
+            }
+
             var tvMazeId = TvHelpers.GetTvMazeId(info.SeriesProviderIds);
             if (!tvMazeId.HasValue)
             {
                 // Requires a TVMaze id.
                 return null;
             }
-
-            var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
 
             var allEpisodes = (await _memoryCache.GetOrCreateAsync($"{MemoryCachePrefix}_show_{tvMazeId.Value}", async entry =>
             {
@@ -263,6 +279,30 @@ namespace Jellyfin.Plugin.TvMaze.Providers
             episode.Overview = TvHelpers.GetStrippedHtml(tvMazeEpisode.Summary);
             episode.SetProviderId(TvMazePlugin.ProviderId, tvMazeEpisode.Id.ToString(CultureInfo.InvariantCulture));
 
+            return episode;
+        }
+
+        private static Episode MapEpisode(TvMazeEpisode tvMazeEpisode)
+        {
+            var episode = new Episode
+            {
+                Name = tvMazeEpisode.Name,
+                ParentIndexNumber = tvMazeEpisode.Season,
+                IndexNumber = tvMazeEpisode.Number,
+                Overview = TvHelpers.GetStrippedHtml(tvMazeEpisode.Summary)
+            };
+
+            if (DateTime.TryParse(tvMazeEpisode.AirDate, out var airDate))
+            {
+                episode.PremiereDate = airDate;
+            }
+
+            if (tvMazeEpisode.Runtime.HasValue)
+            {
+                episode.RunTimeTicks = TimeSpan.FromTicks(tvMazeEpisode.Runtime.Value).Ticks;
+            }
+
+            episode.SetProviderId(TvMazePlugin.ProviderId, tvMazeEpisode.Id.ToString(CultureInfo.InvariantCulture));
             return episode;
         }
 

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonImageProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonImageProvider.cs
@@ -64,12 +64,13 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                     return Enumerable.Empty<RemoteImageInfo>();
                 }
 
-                if (!season.IndexNumber.HasValue)
+                var directSeasonId = TvHelpers.GetTvMazeId(season.ProviderIds);
+                if (!season.IndexNumber.HasValue && !directSeasonId.HasValue)
                 {
                     return Enumerable.Empty<RemoteImageInfo>();
                 }
 
-                var imageResults = await GetSeasonImagesInternal(series, season.IndexNumber.Value).ConfigureAwait(false);
+                var imageResults = await GetSeasonImagesInternal(series, directSeasonId, season.IndexNumber ?? 0).ConfigureAwait(false);
                 _logger.LogInformation("[GetImages] Images found for {Name}: {@Images}", item.Name, imageResults);
                 return imageResults;
             }
@@ -86,7 +87,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
             return _httpClientFactory.CreateClient(NamedClient.Default).GetAsync(new Uri(url), cancellationToken);
         }
 
-        private async Task<IEnumerable<RemoteImageInfo>> GetSeasonImagesInternal(Series series, int seasonNumber)
+        private async Task<IEnumerable<RemoteImageInfo>> GetSeasonImagesInternal(Series series, int? directSeasonId, int seasonNumber)
         {
             var tvMazeId = TvHelpers.GetTvMazeId(series.ProviderIds);
             if (tvMazeId == null)
@@ -105,7 +106,10 @@ namespace Jellyfin.Plugin.TvMaze.Providers
             var imageResults = new List<RemoteImageInfo>();
             foreach (var tvMazeSeason in tvMazeSeasons)
             {
-                if (tvMazeSeason.Number == seasonNumber)
+                var isMatch = (directSeasonId.HasValue && tvMazeSeason.Id == directSeasonId.Value)
+                    || tvMazeSeason.Number == seasonNumber;
+
+                if (isMatch)
                 {
                     if (tvMazeSeason.Image?.Original != null)
                     {

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonProvider.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using TvMaze.Api.Client;
 using TvMaze.Api.Client.Configuration;
@@ -20,18 +21,25 @@ namespace Jellyfin.Plugin.TvMaze.Providers
     /// </summary>
     public class TvMazeSeasonProvider : IRemoteMetadataProvider<Season, SeasonInfo>
     {
+        private const string MemoryCachePrefix = "tvmaze_";
+        private static readonly TimeSpan _absoluteCacheExpiration = TimeSpan.FromMinutes(15);
+        private static readonly TimeSpan _slidingCacheExpiration = TimeSpan.FromMinutes(2);
+
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<TvMazeSeasonProvider> _logger;
+        private readonly IMemoryCache _memoryCache;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TvMazeSeasonProvider"/> class.
         /// </summary>
         /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
         /// <param name="logger">Instance of the <see cref="ILogger{TvMazeSeasonProvider}"/>.</param>
-        public TvMazeSeasonProvider(IHttpClientFactory httpClientFactory, ILogger<TvMazeSeasonProvider> logger)
+        /// <param name="memoryCache">Instance of <see cref="IMemoryCache"/>.</param>
+        public TvMazeSeasonProvider(IHttpClientFactory httpClientFactory, ILogger<TvMazeSeasonProvider> logger, IMemoryCache memoryCache)
         {
             _httpClientFactory = httpClientFactory;
             _logger = logger;
+            _memoryCache = memoryCache;
         }
 
         /// <inheritdoc />
@@ -73,9 +81,9 @@ namespace Jellyfin.Plugin.TvMaze.Providers
 
             try
             {
-                if (!info.IndexNumber.HasValue)
+                if (!info.IndexNumber.HasValue && TvHelpers.GetTvMazeId(info.ProviderIds) == null)
                 {
-                    // Requires season number.
+                    // Requires either a season number or a direct TVMaze season ID.
                     return result;
                 }
 
@@ -110,8 +118,16 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                 return null;
             }
 
+            var directSeasonId = TvHelpers.GetTvMazeId(info.ProviderIds);
+
             var tvMazeClient = new TvMazeClient(_httpClientFactory.CreateClient(NamedClient.Default), new RetryRateLimitingStrategy());
-            var tvMazeSeasons = await tvMazeClient.Shows.GetShowSeasonsAsync(tvMazeId.Value).ConfigureAwait(false);
+            var tvMazeSeasons = await _memoryCache.GetOrCreateAsync($"{MemoryCachePrefix}_show_seasons_{tvMazeId.Value}", async entry =>
+            {
+                entry
+                    .SetAbsoluteExpiration(_absoluteCacheExpiration)
+                    .SetSlidingExpiration(_slidingCacheExpiration);
+                return await tvMazeClient.Shows.GetShowSeasonsAsync(tvMazeId.Value).ConfigureAwait(false);
+            }).ConfigureAwait(false);
             if (tvMazeSeasons == null)
             {
                 return null;
@@ -119,7 +135,10 @@ namespace Jellyfin.Plugin.TvMaze.Providers
 
             foreach (var tvMazeSeason in tvMazeSeasons)
             {
-                if (tvMazeSeason.Number == info.IndexNumber)
+                var isMatch = (directSeasonId.HasValue && tvMazeSeason.Id == directSeasonId.Value)
+                    || tvMazeSeason.Number == info.IndexNumber;
+
+                if (isMatch)
                 {
                     var season = new Season
                     {


### PR DESCRIPTION
When the Jellyfin core resolvers parse a provider ID from a folder or file name (e.g. Season 1 [tvmazeid-12345]), the ID is now stored in the item's ProviderIds before metadata providers run.

This change makes the TVMaze plugin use those IDs (which also can be changed in metadata edit) directly rather than always requiring a full series lookup.

- TvMazeSeasonProvider: Uses the directly specified (path or entered metadata) to search for a matching TvMazeSeasonID or matching Season Number.  Also now caches the season list from `tvMazeClient.Shows.GetShowSeasonsAsync()`
- TvMazeSeasonImageProvider: Uses the direct (path or metadata entered) Season ID to match the season or falls back to the old logic of running through all the series' seasons to match by Season Number

- TvMazeEpisodeProvider: Uses the direct API call `tvMazeClient.Episodes.GetEpisodeMainInformationAsync()` to grab the episode, will cache the reply. If not found, falls-back to the old logic of looking through all episodes. 

This builds on the [Main Jellyfin PR #16472](https://github.com/jellyfin/jellyfin/pull/16472)