### PR TITLE
Updated TvMazePlugin.cs to have a const string value of "TvMaze" for the ProviderName and ProviderId.

### DIFF
--- a/Jellyfin.Plugin.TvMaze/ExternalIds/TvMazeEpisodeExternalId.cs
+++ b/Jellyfin.Plugin.TvMaze/ExternalIds/TvMazeEpisodeExternalId.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.TvMaze.ExternalIds
     public class TvMazeEpisodeExternalId : IExternalId
     {
         /// <inheritdoc />
-        public string ProviderName => "TVmaze";
+        public string ProviderName => TvMazePlugin.ProviderName;
 
         /// <inheritdoc />
         public string Key => TvMazePlugin.ProviderId;

--- a/Jellyfin.Plugin.TvMaze/ExternalIds/TvMazeSeasonExternalId.cs
+++ b/Jellyfin.Plugin.TvMaze/ExternalIds/TvMazeSeasonExternalId.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.TvMaze.ExternalIds
     public class TvMazeSeasonExternalId : IExternalId
     {
         /// <inheritdoc />
-        public string ProviderName => "TVmaze";
+        public string ProviderName => TvMazePlugin.ProviderName;
 
         /// <inheritdoc />
         public string Key => TvMazePlugin.ProviderId;

--- a/Jellyfin.Plugin.TvMaze/ExternalIds/TvMazeSeriesExternalId.cs
+++ b/Jellyfin.Plugin.TvMaze/ExternalIds/TvMazeSeriesExternalId.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.TvMaze.ExternalIds
     public class TvMazeSeriesExternalId : IExternalId
     {
         /// <inheritdoc />
-        public string ProviderName => "TVmaze";
+        public string ProviderName => TvMazePlugin.ProviderName;
 
         /// <inheritdoc />
         public string Key => TvMazePlugin.ProviderId;

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeEpisodeImageProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeEpisodeImageProvider.cs
@@ -84,7 +84,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                     imageResults.Add(new RemoteImageInfo
                     {
                         Url = tvMazeEpisode.Image.Original,
-                        ProviderName = TvMazePlugin.ProviderName,
+                        ProviderName = Name,
                         Language = "en",
                         Type = ImageType.Primary
                     });

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonImageProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeasonImageProvider.cs
@@ -89,7 +89,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
         private async Task<IEnumerable<RemoteImageInfo>> GetSeasonImagesInternal(Series series, int seasonNumber)
         {
             var tvMazeId = TvHelpers.GetTvMazeId(series.ProviderIds);
-            if (tvMazeId == null)
+            if (!tvMazeId.HasValue)
             {
                 // Requires series TVMaze id.
                 return Enumerable.Empty<RemoteImageInfo>();
@@ -112,7 +112,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                         imageResults.Add(new RemoteImageInfo
                         {
                             Url = tvMazeSeason.Image.Original,
-                            ProviderName = TvMazePlugin.ProviderName,
+                            ProviderName = Name,
                             Language = "en",
                             Type = ImageType.Primary
                         });

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeriesImageProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeriesImageProvider.cs
@@ -85,7 +85,7 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                         imageResults.Add(new RemoteImageInfo
                         {
                             Url = image.Resolutions.Original.Url,
-                            ProviderName = TvMazePlugin.ProviderName,
+                            ProviderName = Name,
                             Language = "en",
                             Type = GetImageType(image.Type.Value)
                         });

--- a/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeriesProvider.cs
+++ b/Jellyfin.Plugin.TvMaze/Providers/TvMazeSeriesProvider.cs
@@ -145,9 +145,11 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                     return result;
                 }
 
-                var series = new Series();
-                series.Name = tvMazeShow.Name;
-                series.Genres = tvMazeShow.Genres.ToArray();
+                var series = new Series
+                {
+                    Name = tvMazeShow.Name,
+                    Genres = tvMazeShow.Genres.ToArray()
+                };
 
                 if (!string.IsNullOrWhiteSpace(tvMazeShow.Network?.Name))
                 {
@@ -193,14 +195,15 @@ namespace Jellyfin.Plugin.TvMaze.Providers
                 var castMembers = await tvMazeClient.Shows.GetShowCastAsync(tvMazeShow.Id).ConfigureAwait(false);
                 foreach (var castMember in castMembers)
                 {
-                    var personInfo = new PersonInfo();
+                    var personInfo = new PersonInfo
+                    {
+                        Name = castMember.Person.Name,
+                        Role = castMember.Character.Name,
+                        Type = PersonKind.Actor,
+                        ImageUrl = castMember.Person.Image?.Original
+                                          ?? castMember.Person.Image?.Medium
+                    };
                     personInfo.SetProviderId(TvMazePlugin.ProviderId, castMember.Person.Id.ToString(CultureInfo.InvariantCulture));
-                    personInfo.Name = castMember.Person.Name;
-                    personInfo.Role = castMember.Character.Name;
-                    personInfo.Type = PersonKind.Actor;
-                    personInfo.ImageUrl = castMember.Person.Image?.Original
-                                          ?? castMember.Person.Image?.Medium;
-
                     result.AddPerson(personInfo);
                 }
 

--- a/Jellyfin.Plugin.TvMaze/TvMazePlugin.cs
+++ b/Jellyfin.Plugin.TvMaze/TvMazePlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Jellyfin.Plugin.TvMaze.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
@@ -11,15 +11,7 @@ namespace Jellyfin.Plugin.TvMaze
     /// </summary>
     public class TvMazePlugin : BasePlugin<PluginConfiguration>
     {
-        /// <summary>
-        /// Gets the provider name.
-        /// </summary>
-        public const string ProviderName = "TVmaze";
-
-        /// <summary>
-        /// Gets the provider id.
-        /// </summary>
-        public const string ProviderId = "TVmaze";
+        private const string _ProviderName = "TvMaze";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TvMazePlugin"/> class.
@@ -36,6 +28,16 @@ namespace Jellyfin.Plugin.TvMaze
         /// Gets current plugin instance.
         /// </summary>
         public static TvMazePlugin? Instance { get; private set; }
+
+        /// <summary>
+        /// Gets the provider name.
+        /// </summary>
+        public static string ProviderName => _ProviderName;
+
+        /// <summary>
+        /// Gets the provider id.
+        /// </summary>
+        public static string ProviderId => _ProviderName;
 
         /// <inheritdoc />
         public override string Name => ProviderName;


### PR DESCRIPTION
This fixes "Jellyfin.Plugin.TvMaze.Providers.TvMazeSeriesImageProvider: [GetImages] TVMaze id is required;" that shows up in the Jellyfin logs files.

Fixed other little changes as suggested by VisualStudio. Mostly simplifying object initializations.

Alternate Fix for #57 than [shadowghost/upgrade#61](https://github.com/jellyfin/jellyfin-plugin-tvmaze/pull/61)